### PR TITLE
Add optional quality parameter to Rodfile lines

### DIFF
--- a/r.py
+++ b/r.py
@@ -183,6 +183,14 @@ class R(object):
 	def has_tool(name) -> bool:
 		return which(name) is not None
 
+	@staticmethod
+	def _quality_flags(quality) -> str:
+		if quality is None:
+			return ""
+		if quality == 100:
+			return " -quality 100 -define webp:lossless=true"
+		return f" -quality {quality}"
+
 	def check_for_inkscape(self):
 		if "/" in self.path_inkscape:
 			if os.path.exists(self.path_inkscape) is False:
@@ -308,7 +316,7 @@ class R(object):
 
 		self.lock.update("xcf2pdf", width, height, in_file, out_file)
 
-	def webp2webp(self, width, height, out_file, in_file):
+	def webp2webp(self, width, height, out_file, in_file, quality=None):
 		w = width
 		h = height
 
@@ -320,19 +328,20 @@ class R(object):
 		in_file = os.path.abspath(in_file)
 		out_file = os.path.abspath(out_file)
 
-		if self.lock.check_for_skippage("webp2webp", width, height, in_file, out_file):
+		if self.lock.check_for_skippage("webp2webp", width, height, in_file, out_file, quality):
 			return None
 
+		q_flags = R._quality_flags(quality)
 		cmd = self.path_convert + ' "%s"' % in_file
-		cmd = '%s -scale %sx%s "%s"' % (cmd, w, h, out_file)
+		cmd = '%s -scale %sx%s%s "%s"' % (cmd, w, h, q_flags, out_file)
 
 		os.system(cmd)
 
-		self.lock.update("webp2webp", width, height, in_file, out_file)
+		self.lock.update("webp2webp", width, height, in_file, out_file, quality)
 
 		return out_file
 
-	def png2png(self, width, height, out_file, in_file):
+	def png2png(self, width, height, out_file, in_file, quality=None):
 		w = width
 		h = height
 
@@ -344,15 +353,16 @@ class R(object):
 		in_file = os.path.abspath(in_file)
 		out_file = os.path.abspath(out_file)
 
-		if self.lock.check_for_skippage("png2png", width, height, in_file, out_file):
+		if self.lock.check_for_skippage("png2png", width, height, in_file, out_file, quality):
 			return None
 
+		q_flags = R._quality_flags(quality)
 		cmd = self.path_convert + ' "%s"' % in_file
-		cmd = '%s -scale %sx%s "%s"' % (cmd, w, h, out_file)
+		cmd = '%s -scale %sx%s%s "%s"' % (cmd, w, h, q_flags, out_file)
 
 		os.system(cmd)
 
-		self.lock.update("png2png", width, height, in_file, out_file)
+		self.lock.update("png2png", width, height, in_file, out_file, quality)
 
 		return out_file
 
@@ -425,7 +435,7 @@ class R(object):
 	def svg2pngs(self, width1x, height1x, out_file, in_file):
 		return self.svg2png_r(width1x, height1x, out_file, in_file)
 
-	def svg2webps(self, width1x, height1x, out_file, in_file):
+	def svg2webps(self, width1x, height1x, out_file, in_file, quality=None):
 
 		w = width1x
 		h = height1x
@@ -442,18 +452,19 @@ class R(object):
 		svg_path = os.path.abspath(in_file)
 		webp_path = os.path.abspath(out_file)
 
-		if self.lock.check_for_skippage("svg2webp", width1x, height1x, svg_path, webp_path):
+		if self.lock.check_for_skippage("svg2webp", width1x, height1x, svg_path, webp_path, quality):
 			return None
 
+		q_flags = R._quality_flags(quality).strip() or None
 		out_file_png = webp_path.replace(".webp", "-temp.png")
 		self.svg2png(width1x, height1x, out_file_png, svg_path, update_lock=False)
-		self.convert(out_file_png, webp_path)
+		self.convert(out_file_png, webp_path, q_flags)
 		os.remove(out_file_png)
-		self.lock.update("svg2webp", width1x, height1x, svg_path, webp_path)
+		self.lock.update("svg2webp", width1x, height1x, svg_path, webp_path, quality)
 		return webp_path
 
-	def svg2webp(self, width, height, webp_file, svg_file, options=None):
-		return self.svg2webps(width, height, webp_file, svg_file)
+	def svg2webp(self, width, height, webp_file, svg_file, options=None, quality=None):
+		return self.svg2webps(width, height, webp_file, svg_file, quality)
 
 	def png2pngs_r(self, w1x, h1x, out_file, in_file):
 		width1x = RUtils.number_from_object(w1x)

--- a/rlock.py
+++ b/rlock.py
@@ -26,11 +26,13 @@ class RLock(object):
 		f.write(js)
 		f.close()
 
-	def _key(self, method: str, width: str, height: str, input: str, output: str) -> str:
+	def _key(self, method: str, width: str, height: str, input: str, output: str, quality: Optional[int] = None) -> str:
 		cwd = Path(os.getcwd())
 		rel_input = Path(input).relative_to(cwd)
 		rel_output = Path(output).relative_to(cwd)
 		key = f"{method}|{width}x{height}|{rel_input}->{rel_output}"
+		if quality is not None:
+			key += f"|q={quality}"
 		return key
 
 	def _create_hash(self, file_path: str) -> Optional[str]:
@@ -42,11 +44,11 @@ class RLock(object):
 				sha256_hash.update(byte_block)
 			return sha256_hash.hexdigest()
 
-	def check_for_skippage(self, method: str, width: str, height: str, input: str, output: str) -> bool:
+	def check_for_skippage(self, method: str, width: str, height: str, input: str, output: str, quality: Optional[int] = None) -> bool:
 		if not os.path.exists(input) or not os.path.exists(output):
 			return False
 
-		key = self._key(method, width, height, input, output)
+		key = self._key(method, width, height, input, output, quality)
 
 		d = self._load_lock_file()
 		if d is None:
@@ -64,8 +66,8 @@ class RLock(object):
 
 		return True
 
-	def update(self, method: str, width: str, height: str, input: str, output: str):
-		key = self._key(method, width, height, input, output)
+	def update(self, method: str, width: str, height: str, input: str, output: str, quality: Optional[int] = None):
+		key = self._key(method, width, height, input, output, quality)
 		input_hash = self._create_hash(input)
 		output_hash = self._create_hash(output)
 

--- a/rplatform/base.py
+++ b/rplatform/base.py
@@ -21,6 +21,7 @@ class RBase(object):
 		svg = None
 		png = None
 		action = None
+		quality = None
 
 		if not line.startswith("#"):
 
@@ -48,7 +49,15 @@ class RBase(object):
 						succeeded = True
 					if len(comps) > 0:
 						png = comps[0]
-		return succeeded, method, w, h, svg, png, action
+						comps = comps[1:len(comps)]
+					for extra in comps:
+						extra = extra.strip()
+						if extra.startswith("q="):
+							try:
+								quality = int(extra[2:])
+							except ValueError:
+								pass
+		return succeeded, method, w, h, svg, png, action, quality
 
 	@staticmethod
 	def script_for_line(line):
@@ -86,7 +95,7 @@ class RBase(object):
 			if script is not None:
 				os.system(script)
 
-			(succeeded, method, w, h, sfile, png, action) = RBase.components_for_line(line)
+			(succeeded, method, w, h, sfile, png, action, quality) = RBase.components_for_line(line)
 			if not succeeded:
 				continue
 			if sfile is None:
@@ -102,12 +111,12 @@ class RBase(object):
 				if sfile.endswith(".xcf"):
 					self.xcf2pngs(w, h, sfile, png)
 				elif sfile.endswith(".png") or sfile.endswith(".jpg") or sfile.endswith(".jpeg"):
-					self.png2pngs(w, h, sfile, png)
+					self.png2pngs(w, h, sfile, png, quality=quality)
 				elif sfile.endswith(".webp"):
-					self.webp2webps(w, h, sfile, png)
+					self.webp2webps(w, h, sfile, png, quality=quality)
 				else:
 					if png.endswith(".webp"):
-						ret = self.svg2webps(w, h, sfile, png)
+						ret = self.svg2webps(w, h, sfile, png, quality=quality)
 					else:
 						ret = self.svg2pngs(w, h, sfile, png)
 			elif method == "asset":

--- a/rplatform/droid.py
+++ b/rplatform/droid.py
@@ -63,19 +63,19 @@ class RDroid(RBase):
 	def svg2pngs(self, w_1x, h_1x, svg_file, out_name=None):
 		return self.svg2png(w_1x, h_1x, svg_file, out_name)
 
-	def png2png(self, w_1x, h_1x, svg_file, out_name=None):
+	def png2png(self, w_1x, h_1x, svg_file, out_name=None, quality=None):
 		rets = []
 		for density in self.densities:
 			out_path = self.out_path_from_out_name(density, svg_file, out_name)
 			w = RUtils.number_from_object(w_1x)*density.scale
 			h = RUtils.number_from_object(h_1x)*density.scale
-			r = self.r.png2png(w, h, out_path, svg_file)
+			r = self.r.png2png(w, h, out_path, svg_file, quality=quality)
 			if r is not None:
 				rets.append(r)
 		return rets
 
-	def png2pngs(self, w_1x, h_1x, svg_file, out_name=None):
-		return self.png2png(w_1x, h_1x, svg_file, out_name)
+	def png2pngs(self, w_1x, h_1x, svg_file, out_name=None, quality=None):
+		return self.png2png(w_1x, h_1x, svg_file, out_name, quality=quality)
 
 	def xcf2png(self, w_1x, h_1x, xcf_file, out_name=None):
 		rets = []

--- a/rplatform/flutter.py
+++ b/rplatform/flutter.py
@@ -51,13 +51,13 @@ class RFlutter(RBase):
 				rets.append(r)
 		return rets
 
-	def svg2webp(self, w_1x, h_1x, svg_file, out_name=None):
+	def svg2webp(self, w_1x, h_1x, svg_file, out_name=None, quality=None):
 		rets = []
 		for density in self.densities:
 			out_path = self.out_path_from_out_name(density, svg_file, out_name)
 			w = RUtils.number_from_object(w_1x) * density.scale
 			h = RUtils.number_from_object(h_1x) * density.scale
-			r = self.r.svg2webp(w, h, out_path, svg_file)
+			r = self.r.svg2webp(w, h, out_path, svg_file, quality=quality)
 			if r is not None:
 				rets.append(r)
 		return rets
@@ -65,36 +65,36 @@ class RFlutter(RBase):
 	def svg2pngs(self, w_1x, h_1x, svg_file, out_name=None):
 		return self.svg2png(w_1x, h_1x, svg_file, out_name)
 
-	def svg2webps(self, w_1x, h_1x, svg_file, out_name=None):
-		return self.svg2webp(w_1x, h_1x, svg_file, out_name)
+	def svg2webps(self, w_1x, h_1x, svg_file, out_name=None, quality=None):
+		return self.svg2webp(w_1x, h_1x, svg_file, out_name, quality=quality)
 
-	def png2png(self, w_1x, h_1x, svg_file, out_name=None):
+	def png2png(self, w_1x, h_1x, svg_file, out_name=None, quality=None):
 		rets = []
 		for density in self.densities:
 			out_path = self.out_path_from_out_name(density, svg_file, out_name)
 			w = RUtils.number_from_object(w_1x) * density.scale
 			h = RUtils.number_from_object(h_1x) * density.scale
-			r = self.r.png2png(w, h, out_path, svg_file)
+			r = self.r.png2png(w, h, out_path, svg_file, quality=quality)
 			if r is not None:
 				rets.append(r)
 		return rets
 
-	def png2pngs(self, w_1x, h_1x, svg_file, out_name=None):
-		return self.png2png(w_1x, h_1x, svg_file, out_name)
+	def png2pngs(self, w_1x, h_1x, svg_file, out_name=None, quality=None):
+		return self.png2png(w_1x, h_1x, svg_file, out_name, quality=quality)
 
-	def webp2webp(self, w_1x, h_1x, svg_file, out_name=None):
+	def webp2webp(self, w_1x, h_1x, svg_file, out_name=None, quality=None):
 		rets = []
 		for density in self.densities:
 			out_path = self.out_path_from_out_name(density, svg_file, out_name)
 			w = RUtils.number_from_object(w_1x) * density.scale
 			h = RUtils.number_from_object(h_1x) * density.scale
-			r = self.r.webp2webp(w, h, out_path, svg_file)
+			r = self.r.webp2webp(w, h, out_path, svg_file, quality=quality)
 			if r is not None:
 				rets.append(r)
 		return rets
 
-	def webp2webps(self, w_1x, h_1x, svg_file, out_name=None):
-		return self.webp2webp(w_1x, h_1x, svg_file, out_name)
+	def webp2webps(self, w_1x, h_1x, svg_file, out_name=None, quality=None):
+		return self.webp2webp(w_1x, h_1x, svg_file, out_name, quality=quality)
 
 	def xcf2png(self, w_1x, h_1x, xcf_file, out_name=None):
 		rets = []

--- a/rplatform/web.py
+++ b/rplatform/web.py
@@ -51,13 +51,13 @@ class RWeb(RBase):
 				rets.append(r)
 		return rets
 
-	def svg2webp(self, w_1x, h_1x, svg_file, out_name=None):
+	def svg2webp(self, w_1x, h_1x, svg_file, out_name=None, quality=None):
 		rets = []
 		for density in self.densities:
 			out_path = self.out_path_from_out_name(density, svg_file, out_name)
 			w = RUtils.number_from_object(w_1x) * density.scale
 			h = RUtils.number_from_object(h_1x) * density.scale
-			r = self.r.svg2webp(w, h, out_path, svg_file)
+			r = self.r.svg2webp(w, h, out_path, svg_file, quality=quality)
 			if r is not None:
 				rets.append(r)
 		return rets
@@ -65,36 +65,36 @@ class RWeb(RBase):
 	def svg2pngs(self, w_1x, h_1x, svg_file, out_name=None):
 		return self.svg2png(w_1x, h_1x, svg_file, out_name)
 
-	def svg2webps(self, w_1x, h_1x, svg_file, out_name=None):
-		return self.svg2webp(w_1x, h_1x, svg_file, out_name)
+	def svg2webps(self, w_1x, h_1x, svg_file, out_name=None, quality=None):
+		return self.svg2webp(w_1x, h_1x, svg_file, out_name, quality=quality)
 
-	def png2png(self, w_1x, h_1x, svg_file, out_name=None):
+	def png2png(self, w_1x, h_1x, svg_file, out_name=None, quality=None):
 		rets = []
 		for density in self.densities:
 			out_path = self.out_path_from_out_name(density, svg_file, out_name)
 			w = RUtils.number_from_object(w_1x) * density.scale
 			h = RUtils.number_from_object(h_1x) * density.scale
-			r = self.r.png2png(w, h, out_path, svg_file)
+			r = self.r.png2png(w, h, out_path, svg_file, quality=quality)
 			if r is not None:
 				rets.append(r)
 		return rets
 
-	def png2pngs(self, w_1x, h_1x, svg_file, out_name=None):
-		return self.png2png(w_1x, h_1x, svg_file, out_name)
+	def png2pngs(self, w_1x, h_1x, svg_file, out_name=None, quality=None):
+		return self.png2png(w_1x, h_1x, svg_file, out_name, quality=quality)
 
-	def webp2webp(self, w_1x, h_1x, svg_file, out_name=None):
+	def webp2webp(self, w_1x, h_1x, svg_file, out_name=None, quality=None):
 		rets = []
 		for density in self.densities:
 			out_path = self.out_path_from_out_name(density, svg_file, out_name)
 			w = RUtils.number_from_object(w_1x) * density.scale
 			h = RUtils.number_from_object(h_1x) * density.scale
-			r = self.r.webp2webp(w, h, out_path, svg_file)
+			r = self.r.webp2webp(w, h, out_path, svg_file, quality=quality)
 			if r is not None:
 				rets.append(r)
 		return rets
 
-	def webp2webps(self, w_1x, h_1x, svg_file, out_name=None):
-		return self.webp2webp(w_1x, h_1x, svg_file, out_name)
+	def webp2webps(self, w_1x, h_1x, svg_file, out_name=None, quality=None):
+		return self.webp2webp(w_1x, h_1x, svg_file, out_name, quality=quality)
 
 	def xcf2png(self, w_1x, h_1x, xcf_file, out_name=None):
 		rets = []


### PR DESCRIPTION
## Summary

- Adds an optional `q=N` parameter (integer, 1-100) to Rodfile image lines, e.g. `327,183,input.png,output.webp,q=90`
- When omitted, behavior is unchanged
- `q=100` passes `-quality 100 -define webp:lossless=true` to ImageMagick, producing lossless WebP output
- Any other value passes `-quality N` to ImageMagick
- The quality value is included in the lock key, so changing `q=` on a line invalidates the cached output and triggers regeneration

## Files changed

- `rplatform/base.py` - parses `q=N` from line components; threads `quality` into dispatch calls
- `r.py` - adds `_quality_flags()` helper; updates `svg2webps`, `webp2webp`, `png2png` to accept and apply quality
- `rlock.py` - includes quality in cache key
- `rplatform/flutter.py`, `web.py`, `droid.py` - updated method signatures to accept and forward quality